### PR TITLE
style: satisfy bookmark automation lint gate

### DIFF
--- a/bookmark_automation/__main__.py
+++ b/bookmark_automation/__main__.py
@@ -1,4 +1,3 @@
 from .cli import main
 
-
 raise SystemExit(main())

--- a/bookmark_automation/cli.py
+++ b/bookmark_automation/cli.py
@@ -22,7 +22,6 @@ from .service import BookmarkAutomation
 from .store import AutomationStore
 from .worker import InferenceWorker
 
-
 BRASILIA = ZoneInfo("America/Sao_Paulo")
 DEFAULT_VIDEO_DIR = Path("/workspace/twitter-bookmark-processor/data/videos")
 DEFAULT_NOTE_DIR = Path("/workspace/notes/Sources/twitter")

--- a/bookmark_automation/content.py
+++ b/bookmark_automation/content.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import ipaddress
 import http.client
+import ipaddress
 import json
 import socket
 import ssl
@@ -15,7 +15,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Iterable
 from urllib.parse import urljoin, urlparse
-
 
 _URL_KEYS = ("expanded_url", "expandedUrl", "unwound_url", "unwoundUrl", "url")
 _X_HOSTS = {"x.com", "twitter.com", "pbs.twimg.com", "video.twimg.com"}

--- a/bookmark_automation/note_coverage.py
+++ b/bookmark_automation/note_coverage.py
@@ -6,7 +6,6 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
-
 _BOOKMARK_ID = re.compile(
     r"^bookmark_id:\s*(?:\"([^\"]+)\"|'([^']+)'|([^\s#]+))\s*$",
     re.MULTILINE,

--- a/bookmark_automation/service.py
+++ b/bookmark_automation/service.py
@@ -12,7 +12,6 @@ from .content import embedded_x_article_raw_text
 from .store import AutomationStore, EnqueueResult
 from .store import DecisionResult as StoreDecisionResult
 
-
 _VOLATILE_REVISION_FIELDS = {
     "metrics",
     "_raw",

--- a/bookmark_automation/store.py
+++ b/bookmark_automation/store.py
@@ -14,7 +14,6 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Iterable
 
-
 _SEMANTIC_TASK_KINDS = (
     "quick",
     "fetch_article",

--- a/tests/bookmark_automation/test_content.py
+++ b/tests/bookmark_automation/test_content.py
@@ -11,8 +11,8 @@ import pytest
 import bookmark_automation.content as content_module
 from bookmark_automation.content import (
     ArticleContentError,
-    URLSecurityError,
     RecallError,
+    URLSecurityError,
     fetch_article,
     recall_second_brain,
     select_external_url,

--- a/tests/bookmark_automation/test_systemd.py
+++ b/tests/bookmark_automation/test_systemd.py
@@ -2,7 +2,6 @@
 
 from pathlib import Path
 
-
 SYSTEMD = Path(__file__).parents[2] / "bookmark_automation" / "systemd"
 BOOTSTRAP_MARKER = (
     "ConditionPathExists=/workspace/twitter-bookmark-processor/data/"


### PR DESCRIPTION
## Summary
- apply Ruff import ordering and spacing fixes
- no functional changes

## Validation
- `ruff check bookmark_automation tests/bookmark_automation`
- `pytest -q tests/bookmark_automation` (168 passed)

Bot review intentionally not requested: formatting-only follow-up with full local gates.