### PR TITLE
feat: harden bookmark automation operations

### DIFF
--- a/bookmark_automation/README.md
+++ b/bookmark_automation/README.md
@@ -210,7 +210,7 @@ are versioned under `prompts/v1/` and `schemas/v1/`.
 
 ## Staged systemd operation
 
-The repository stages six service/timer pairs under `systemd/`; it does not
+The repository stages seven service/timer pairs under `systemd/`; it does not
 copy them to `/etc/systemd/system`, start them, or enable them. Their paths
 assume the merged checkout lives at `/workspace/twitter-bookmark-processor`.
 
@@ -222,6 +222,7 @@ assume the merged checkout lives at `/workspace/twitter-bookmark-processor`.
 | `bookmark-automation-decisions` | 15 seconds | Replay the existing bridge's append-only callback JSONL idempotently. |
 | `bookmark-automation-inference` | 60 seconds | Run provider-neutral `quick`, `deep`, and `aggregate` jobs through subscription CLIs. |
 | `bookmark-automation-periodic` | daily, 07:10 BRT | Freeze incremental digest batches of 25 and advance at most five historical revisions. |
+| `bookmark-automation-maintenance` | every 5 minutes | Alert new dead letters and ambiguous committed effects, checkpoint/measure SQLite WAL, prune completed videos after 30 days, and alert on low disk. |
 
 The templates deliberately use the absolute command requested for near-real-time
 polling:
@@ -373,6 +374,13 @@ PYTHONPATH=/workspace/_scripts/subscription-inference \
 systemd-analyze verify \
   /workspace/twitter-bookmark-processor/bookmark_automation/systemd/*.service \
   /workspace/twitter-bookmark-processor/bookmark_automation/systemd/*.timer
+
+PYTHONPATH=/workspace/twitter-bookmark-processor \
+  /usr/bin/python3 -m bookmark_automation \
+  --db /workspace/twitter-bookmark-processor/data/bookmark-automation.sqlite3 \
+  operational-gate \
+  --path /workspace/twitter-bookmark-processor/data \
+  --min-free-bytes 1073741824
 ```
 
 Before activation, the `status` receipt must report both
@@ -400,7 +408,8 @@ systemctl enable --now \
   bookmark-automation-effects.timer \
   bookmark-automation-decisions.timer \
   bookmark-automation-inference.timer \
-  bookmark-automation-periodic.timer
+  bookmark-automation-periodic.timer \
+  bookmark-automation-maintenance.timer
 ```
 
 After an approved activation, inspect health without revealing stored content:
@@ -418,15 +427,40 @@ revision is watermarked when its frozen job is queued, so deleting that job or
 its coverage row by hand can either lose it from future digests or duplicate it.
 Never repair this state with ad-hoc SQLite updates.
 
-Production activation remains blocked until there is an operator-visible alert
-for new dead letters and a tested, idempotent way to inspect and requeue the same
-job identity. The recovery path must preserve its input snapshot and aggregate
-coverage, record the retry, and distinguish `waiting_provider` (subscription
-temporarily unavailable) from an ordinary terminal failure. The operator must
-also define a separate audited resolution for unresolved `committed_effects`:
-because an irreversible effect may already have happened, they must never be
-blindly requeued. Retention and disk monitoring for the SQLite/WAL and saved
-videos remain required.
+`bookmark-automation-maintenance` sends an operator-visible Telegram alert once
+per dead-letter attempt generation. Inspect and requeue without changing the
+frozen input, attempt history, or aggregate coverage:
+
+```bash
+python3 -m bookmark_automation --db data/bookmark-automation.sqlite3 \
+  dead-letter-list
+python3 -m bookmark_automation --db data/bookmark-automation.sqlite3 \
+  dead-letter-requeue --job-id 42 --reason "provider configuration repaired"
+```
+
+The requeue is idempotent. `waiting_provider` remains a separate non-terminal
+state and is not accepted by the DLQ command.
+
+An unresolved `committed_effect` is alerted separately and never requeued by a
+worker. The operator must record one audited resolution:
+
+```bash
+python3 -m bookmark_automation --db data/bookmark-automation.sqlite3 \
+  committed-effect-list
+python3 -m bookmark_automation --db data/bookmark-automation.sqlite3 \
+  committed-effect-resolve --job-id 43 --resolution confirmed \
+  --reason "Telegram showed the message"
+# Only with positive evidence that the effect did not occur:
+python3 -m bookmark_automation --db data/bookmark-automation.sqlite3 \
+  committed-effect-resolve --job-id 43 --resolution not-delivered \
+  --reason "Bot API request never left the host"
+```
+
+Maintenance checkpoints and reports SQLite/WAL sizes, prunes only expired files
+whose `deliver_video` job is already `done`, and alerts once per low-disk
+incident. Every content/inference worker has an independent 1 GiB free-space
+`ExecCondition`; maintenance deliberately remains runnable so it can prune and
+alert while workers are blocked.
 
 ### Rollback
 
@@ -441,7 +475,8 @@ systemctl disable --now \
   bookmark-automation-effects.timer \
   bookmark-automation-decisions.timer \
   bookmark-automation-inference.timer \
-  bookmark-automation-periodic.timer
+  bookmark-automation-periodic.timer \
+  bookmark-automation-maintenance.timer
 
 systemctl stop \
   bookmark-automation-poll.service \
@@ -449,7 +484,8 @@ systemctl stop \
   bookmark-automation-effects.service \
   bookmark-automation-decisions.service \
   bookmark-automation-inference.service \
-  bookmark-automation-periodic.service
+  bookmark-automation-periodic.service \
+  bookmark-automation-maintenance.service
 ```
 
 Preserve the SQLite database together with its `-wal`/`-shm` files and both
@@ -479,9 +515,9 @@ operator approval and remains blocked until all of these are true:
 - native-X video delivery is canaried without overwriting the original, the
   external-video limitation is accepted, and Source-note permissions are
   checked;
-- dead-letter alerting/requeue, committed-effect recovery, Telegram at-least-once
-  behavior, retention, disk monitoring, and the rollback procedure above are
-  accepted.
+- the maintenance timer, audited DLQ/committed-effect recovery, Telegram
+  append-only callback replay, retention, disk floor, and the rollback
+  procedure above pass their production checks.
 
 A Bird payload that reports video without a usable `media[].videoUrl` remains
 retryable rather than being marked done. No unit may be copied, enabled, or

--- a/bookmark_automation/cli.py
+++ b/bookmark_automation/cli.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import os
 import re
+import shutil
 import socket
 import sys
 from collections import Counter
@@ -16,6 +17,7 @@ from zoneinfo import ZoneInfo
 
 from .effect_worker import EffectWorker
 from .effects import TelegramClient
+from .maintenance import MaintenanceWorker
 from .note_coverage import scan_note_coverage
 from .runner import SubprocessSubscriptionRunner
 from .service import BookmarkAutomation
@@ -94,12 +96,51 @@ def _parser() -> argparse.ArgumentParser:
     )
     gate = commands.add_parser("gate", help="read-only activation gate validation")
     gate.add_argument("--require-note-coverage", action="store_true")
+    operational_gate = commands.add_parser(
+        "operational-gate",
+        help="fail closed when runtime storage is below the safe free-space floor",
+    )
+    operational_gate.add_argument("--path", action="append", required=True)
+    operational_gate.add_argument("--min-free-bytes", type=int, required=True)
     commands.add_parser("status", help="report sidecar queue counts without stored content")
     dead_letter = commands.add_parser(
         "dead-letter-list",
-        help="read-only DLQ inspection; requeue is intentionally unsupported",
+        help="read-only DLQ inspection with explicit audited requeue available",
     )
     dead_letter.add_argument("--limit", type=int, default=100)
+    requeue = commands.add_parser(
+        "dead-letter-requeue",
+        help="explicitly and idempotently requeue one terminal job",
+    )
+    requeue.add_argument("--job-id", type=int, required=True)
+    requeue.add_argument("--reason", required=True)
+    committed = commands.add_parser(
+        "committed-effect-list",
+        help="list irreversible effects that require explicit operator resolution",
+    )
+    committed.add_argument("--limit", type=int, default=100)
+    resolve = commands.add_parser(
+        "committed-effect-resolve",
+        help="audit an operator-confirmed resolution without blind replay",
+    )
+    resolve.add_argument("--job-id", type=int, required=True)
+    resolve.add_argument(
+        "--resolution",
+        choices=("confirmed", "not-delivered"),
+        required=True,
+    )
+    resolve.add_argument("--reason", required=True)
+    maintenance = commands.add_parser(
+        "maintenance",
+        help="alert terminal states, prune completed videos, and monitor storage",
+    )
+    maintenance.add_argument("--video-dir", type=Path, default=DEFAULT_VIDEO_DIR)
+    maintenance.add_argument("--retention-days", type=int, default=30)
+    maintenance.add_argument(
+        "--min-free-bytes",
+        type=int,
+        default=1024 * 1024 * 1024,
+    )
     return parser
 
 
@@ -177,6 +218,20 @@ def main(
         json.dump(result, stdout, sort_keys=True)
         stdout.write("\n")
         return 0 if result["valid"] else 1
+    if args.command == "operational-gate":
+        if args.min_free_bytes <= 0:
+            raise ValueError("min-free-bytes must be positive")
+        free_bytes = min(
+            int(shutil.disk_usage(Path(path)).free) for path in args.path
+        )
+        result = {
+            "free_bytes": free_bytes,
+            "min_free_bytes": args.min_free_bytes,
+            "valid": free_bytes >= args.min_free_bytes,
+        }
+        json.dump(result, stdout, sort_keys=True)
+        stdout.write("\n")
+        return 0 if result["valid"] else 1
     if args.command == "dead-letter-list":
         if not args.db.is_file():
             json.dump({"database_exists": False, "jobs": []}, stdout, sort_keys=True)
@@ -185,7 +240,30 @@ def main(
         store = AutomationStore(args.db, initialize=False)
         jobs = store.dead_letter_snapshot(limit=args.limit)
         json.dump(
-            {"database_exists": True, "jobs": jobs, "requeue_supported": False},
+            {"database_exists": True, "jobs": jobs, "requeue_supported": True},
+            stdout,
+            sort_keys=True,
+        )
+        stdout.write("\n")
+        return 0
+    if args.command == "committed-effect-list":
+        if not args.db.is_file():
+            json.dump(
+                {"database_exists": False, "jobs": [], "resolution_required": False},
+                stdout,
+                sort_keys=True,
+            )
+            stdout.write("\n")
+            return 0
+        jobs = AutomationStore(args.db, initialize=False).committed_effect_snapshot(
+            limit=args.limit
+        )
+        json.dump(
+            {
+                "database_exists": True,
+                "jobs": jobs,
+                "resolution_required": bool(jobs),
+            },
             stdout,
             sort_keys=True,
         )
@@ -284,6 +362,45 @@ def main(
         json.dump(summary, stdout, ensure_ascii=False, sort_keys=True)
         stdout.write("\n")
         return 0
+    if args.command == "dead-letter-requeue":
+        changed = store.requeue_dead_letter(
+            job_id=args.job_id,
+            reason=args.reason,
+            now=datetime.now(UTC),
+        )
+        json.dump(
+            {"changed": changed, "job_id": args.job_id, "state": "pending"},
+            stdout,
+            sort_keys=True,
+        )
+        stdout.write("\n")
+        return 0
+    if args.command == "committed-effect-resolve":
+        changed = store.resolve_committed_effect(
+            job_id=args.job_id,
+            resolution=args.resolution,
+            reason=args.reason,
+            now=datetime.now(UTC),
+        )
+        state = "done" if args.resolution == "confirmed" else "pending"
+        json.dump(
+            {"changed": changed, "job_id": args.job_id, "state": state},
+            stdout,
+            sort_keys=True,
+        )
+        stdout.write("\n")
+        return 0
+    if args.command == "maintenance":
+        result = MaintenanceWorker(
+            store=store,
+            telegram=TelegramClient(environ=os.environ),
+            video_dir=args.video_dir,
+            retention_days=args.retention_days,
+            min_free_bytes=args.min_free_bytes,
+        ).run(now=datetime.now(UTC))
+        json.dump(result, stdout, sort_keys=True)
+        stdout.write("\n")
+        return 0 if result["healthy"] else 1
     if args.command == "decision":
         payload = load_input(args.input)
         if not isinstance(payload, dict):

--- a/bookmark_automation/maintenance.py
+++ b/bookmark_automation/maintenance.py
@@ -1,0 +1,136 @@
+"""Production maintenance, alerting, and retention for bookmark automation."""
+
+from __future__ import annotations
+
+import shutil
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Callable, Protocol
+
+from .effects import TelegramMessage
+from .store import AutomationStore
+
+
+class TelegramSender(Protocol):
+    def send_message(self, message: TelegramMessage, **kwargs: Any) -> Any: ...
+
+
+class MaintenanceWorker:
+    """Run bounded operational checks independently from content workers."""
+
+    def __init__(
+        self,
+        *,
+        store: AutomationStore,
+        telegram: TelegramSender,
+        video_dir: str | Path,
+        retention_days: int = 30,
+        min_free_bytes: int = 1024 * 1024 * 1024,
+        disk_usage: Callable[[Path], Any] = shutil.disk_usage,
+    ) -> None:
+        if retention_days < 0:
+            raise ValueError("retention_days must be non-negative")
+        if min_free_bytes <= 0:
+            raise ValueError("min_free_bytes must be positive")
+        self.store = store
+        self.telegram = telegram
+        self.video_dir = Path(video_dir)
+        self.retention_days = retention_days
+        self.min_free_bytes = min_free_bytes
+        self.disk_usage = disk_usage
+
+    def _prune_videos(self, *, now: datetime) -> tuple[int, int]:
+        completed = self.store.completed_video_bookmark_ids()
+        cutoff = now - timedelta(days=self.retention_days)
+        removed = 0
+        bytes_removed = 0
+        if not self.video_dir.is_dir():
+            return removed, bytes_removed
+        for path in sorted(self.video_dir.glob("*.mp4")):
+            if path.is_symlink() or not path.is_file():
+                continue
+            bookmark_id = path.stem.removesuffix(".telegram")
+            stat = path.stat()
+            modified = datetime.fromtimestamp(stat.st_mtime, tz=now.tzinfo)
+            if bookmark_id not in completed or modified >= cutoff:
+                continue
+            path.unlink()
+            removed += 1
+            bytes_removed += stat.st_size
+        return removed, bytes_removed
+
+    def run(self, *, now: datetime) -> dict[str, int | bool]:
+        checkpoint = self.store.checkpoint_wal()
+        videos_removed, bytes_removed = self._prune_videos(now=now)
+        wal_path = Path(f"{self.store.path}-wal")
+        database_bytes = self.store.path.stat().st_size
+        wal_bytes = wal_path.stat().st_size if wal_path.is_file() else 0
+        usage = self.disk_usage(self.store.path.parent)
+        free_bytes = int(usage.free)
+        healthy = free_bytes >= self.min_free_bytes
+        disk_alerts = 0
+        prior_disk_state = self.store.health_state("disk_low")
+        if not healthy and prior_disk_state != "active":
+            self.telegram.send_message(
+                TelegramMessage(
+                    text=(
+                        "🚨 Bookmark automation: disco baixo\n"
+                        f"Livres: {free_bytes} bytes; mínimo operacional: "
+                        f"{self.min_free_bytes} bytes. Workers permanecerão bloqueados."
+                    )
+                )
+            )
+            self.store.set_health_state("disk_low", "active")
+            disk_alerts = 1
+        elif healthy and prior_disk_state == "active":
+            self.store.set_health_state("disk_low", "inactive")
+        dead_letter_alerts = 0
+        for pending in self.store.pending_dead_letter_alerts():
+            self.telegram.send_message(
+                TelegramMessage(
+                    text=(
+                        "🚨 Bookmark automation: dead letter\n"
+                        f"job {pending['job_id']} · {pending['task_kind']} · "
+                        f"{pending['attempt_count']} tentativa(s)\n"
+                        "Inspecione com dead-letter-list e reencaminhe somente após corrigir a causa."
+                    )
+                )
+            )
+            if self.store.mark_dead_letter_alerted(
+                job_id=int(pending["job_id"]),
+                attempt_count=int(pending["attempt_count"]),
+                now=now,
+            ):
+                dead_letter_alerts += 1
+        committed_effect_alerts = 0
+        for pending in self.store.pending_committed_effect_alerts():
+            self.telegram.send_message(
+                TelegramMessage(
+                    text=(
+                        "⚠️ Bookmark automation: efeito externo ambíguo\n"
+                        f"job {pending['job_id']} · {pending['task_kind']}\n"
+                        "Ele não será repetido automaticamente. Confirme o resultado com "
+                        "committed-effect-resolve."
+                    )
+                )
+            )
+            if self.store.mark_committed_effect_alerted(
+                job_id=int(pending["job_id"]),
+                attempt_id=int(pending["attempt_id"]),
+                now=now,
+            ):
+                committed_effect_alerts += 1
+        return {
+            "bytes_removed": bytes_removed,
+            "committed_effect_alerts": committed_effect_alerts,
+            "database_bytes": database_bytes,
+            "dead_letter_alerts": dead_letter_alerts,
+            "disk_alerts": disk_alerts,
+            "free_bytes": free_bytes,
+            "healthy": healthy,
+            "videos_removed": videos_removed,
+            "wal_bytes": wal_bytes,
+            "wal_checkpoint_busy": checkpoint["busy"],
+            "wal_checkpointed_frames": checkpoint["checkpointed_frames"],
+            "wal_log_frames": checkpoint["log_frames"],
+        }

--- a/bookmark_automation/store.py
+++ b/bookmark_automation/store.py
@@ -272,6 +272,17 @@ class AutomationStore:
                     key TEXT PRIMARY KEY,
                     value TEXT NOT NULL
                 );
+
+                CREATE TABLE IF NOT EXISTS operator_actions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    action_key TEXT NOT NULL UNIQUE,
+                    job_id INTEGER,
+                    action TEXT NOT NULL,
+                    reason TEXT NOT NULL,
+                    detail_json TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    FOREIGN KEY (job_id) REFERENCES jobs(id)
+                );
                 """
             )
             connection.execute(
@@ -814,6 +825,369 @@ class AutomationStore:
                 (limit,),
             ).fetchall()
         return [dict(row) for row in rows]
+
+    def requeue_dead_letter(
+        self,
+        *,
+        job_id: int,
+        reason: str,
+        now: datetime,
+    ) -> bool:
+        """Requeue one terminal job without changing its frozen input or history."""
+        reason = reason.strip()
+        if not reason:
+            raise ValueError("requeue reason is required")
+        with self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            job = connection.execute(
+                "SELECT state FROM jobs WHERE id = ?",
+                (job_id,),
+            ).fetchone()
+            if job is None:
+                raise ValueError(f"job {job_id} does not exist")
+            previous = connection.execute(
+                """
+                SELECT 1 FROM operator_actions
+                WHERE job_id = ? AND action = 'dead_letter_requeue'
+                ORDER BY id DESC LIMIT 1
+                """,
+                (job_id,),
+            ).fetchone()
+            if job["state"] != "dead_letter":
+                if previous is not None and job["state"] == "pending":
+                    return False
+                raise ValueError(f"job {job_id} is not in dead_letter")
+            failed_attempts = int(
+                connection.execute(
+                    """
+                    SELECT COUNT(*) AS total FROM attempts
+                    WHERE job_id = ? AND status = 'failed'
+                    """,
+                    (job_id,),
+                ).fetchone()["total"]
+            )
+            action_key = f"dead_letter_requeue:{job_id}:{failed_attempts}"
+            inserted = connection.execute(
+                """
+                INSERT OR IGNORE INTO operator_actions (
+                    action_key, job_id, action, reason, detail_json, created_at
+                ) VALUES (?, ?, 'dead_letter_requeue', ?, ?, ?)
+                """,
+                (
+                    action_key,
+                    job_id,
+                    reason,
+                    json.dumps({"failed_attempts": failed_attempts}, sort_keys=True),
+                    now.isoformat(),
+                ),
+            ).rowcount
+            if not inserted:
+                return False
+            connection.execute(
+                """
+                UPDATE jobs
+                SET state = 'pending', available_at = ?, lease_owner = NULL,
+                    lease_until = NULL, lease_token = NULL, cancel_requested = 0
+                WHERE id = ? AND state = 'dead_letter'
+                """,
+                (now.isoformat(), job_id),
+            )
+        return True
+
+    def committed_effect_snapshot(self, *, limit: int = 100) -> list[dict[str, Any]]:
+        """List irreversible effects that crossed the boundary without a receipt."""
+        if limit <= 0:
+            raise ValueError("limit must be positive")
+        with self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT jobs.id AS job_id, jobs.bookmark_id, jobs.task_kind,
+                       attempts.id AS attempt_id, attempts.started_at,
+                       attempts.finished_at
+                FROM jobs
+                JOIN attempts ON attempts.job_id = jobs.id
+                WHERE jobs.state = 'leased'
+                  AND attempts.status = 'effect_committed'
+                ORDER BY jobs.id ASC, attempts.id ASC
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+        return [dict(row) for row in rows]
+
+    def pending_dead_letter_alerts(self, *, limit: int = 100) -> list[dict[str, Any]]:
+        """Return dead letters whose current failed-attempt generation was not alerted."""
+        if limit <= 0:
+            raise ValueError("limit must be positive")
+        with self._connect() as connection:
+            rows = connection.execute(
+                """
+                WITH terminal AS (
+                    SELECT jobs.id AS job_id, jobs.task_kind,
+                           COUNT(attempts.id) AS attempt_count
+                    FROM jobs
+                    LEFT JOIN attempts
+                      ON attempts.job_id = jobs.id
+                     AND attempts.status = 'failed'
+                    WHERE jobs.state = 'dead_letter'
+                    GROUP BY jobs.id
+                )
+                SELECT terminal.job_id, terminal.task_kind, terminal.attempt_count
+                FROM terminal
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM operator_actions
+                    WHERE operator_actions.action_key =
+                        'dead_letter_alert:' || terminal.job_id || ':' || terminal.attempt_count
+                )
+                ORDER BY terminal.job_id ASC
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+        return [dict(row) for row in rows]
+
+    def mark_dead_letter_alerted(
+        self,
+        *,
+        job_id: int,
+        attempt_count: int,
+        now: datetime,
+    ) -> bool:
+        """Record alert delivery after Telegram acknowledged the message."""
+        with self._connect() as connection:
+            cursor = connection.execute(
+                """
+                INSERT OR IGNORE INTO operator_actions (
+                    action_key, job_id, action, reason, detail_json, created_at
+                ) VALUES (?, ?, 'dead_letter_alert', 'telegram alert delivered', ?, ?)
+                """,
+                (
+                    f"dead_letter_alert:{job_id}:{attempt_count}",
+                    job_id,
+                    json.dumps({"attempt_count": attempt_count}, sort_keys=True),
+                    now.isoformat(),
+                ),
+            )
+        return bool(cursor.rowcount)
+
+    def pending_committed_effect_alerts(
+        self,
+        *,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Return unresolved committed effects not yet shown to the operator."""
+        if limit <= 0:
+            raise ValueError("limit must be positive")
+        with self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT jobs.id AS job_id, jobs.task_kind,
+                       attempts.id AS attempt_id
+                FROM jobs
+                JOIN attempts ON attempts.job_id = jobs.id
+                WHERE jobs.state = 'leased'
+                  AND attempts.status = 'effect_committed'
+                  AND NOT EXISTS (
+                      SELECT 1 FROM operator_actions
+                      WHERE operator_actions.action_key =
+                          'committed_effect_alert:' || jobs.id || ':' || attempts.id
+                  )
+                ORDER BY jobs.id ASC, attempts.id ASC
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+        return [dict(row) for row in rows]
+
+    def completed_video_bookmark_ids(self) -> set[str]:
+        """Return bookmark IDs whose native-video delivery finished durably."""
+        with self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT bookmark_id FROM jobs
+                WHERE task_kind = 'deliver_video' AND state = 'done'
+                  AND bookmark_id IS NOT NULL
+                """
+            ).fetchall()
+        return {str(row["bookmark_id"]) for row in rows}
+
+    def health_state(self, key: str) -> str | None:
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT value FROM metadata WHERE key = ?",
+                (f"health:{key}",),
+            ).fetchone()
+        return None if row is None else str(row["value"])
+
+    def set_health_state(self, key: str, value: str) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO metadata (key, value) VALUES (?, ?)
+                ON CONFLICT(key) DO UPDATE SET value = excluded.value
+                """,
+                (f"health:{key}", value),
+            )
+
+    def checkpoint_wal(self) -> dict[str, int]:
+        """Run a non-blocking WAL checkpoint and expose only operational counts."""
+        with self._connect() as connection:
+            row = connection.execute("PRAGMA wal_checkpoint(PASSIVE)").fetchone()
+        return {
+            "busy": int(row[0]),
+            "log_frames": int(row[1]),
+            "checkpointed_frames": int(row[2]),
+        }
+
+    def mark_committed_effect_alerted(
+        self,
+        *,
+        job_id: int,
+        attempt_id: int,
+        now: datetime,
+    ) -> bool:
+        """Record a successful operator alert for an ambiguous effect."""
+        with self._connect() as connection:
+            cursor = connection.execute(
+                """
+                INSERT OR IGNORE INTO operator_actions (
+                    action_key, job_id, action, reason, detail_json, created_at
+                ) VALUES (?, ?, 'committed_effect_alert',
+                          'telegram alert delivered', ?, ?)
+                """,
+                (
+                    f"committed_effect_alert:{job_id}:{attempt_id}",
+                    job_id,
+                    json.dumps({"attempt_id": attempt_id}, sort_keys=True),
+                    now.isoformat(),
+                ),
+            )
+        return bool(cursor.rowcount)
+
+    def resolve_committed_effect(
+        self,
+        *,
+        job_id: int,
+        resolution: str,
+        reason: str,
+        now: datetime,
+    ) -> bool:
+        """Resolve an ambiguous irreversible effect without blind replay."""
+        if resolution not in {"confirmed", "not-delivered"}:
+            raise ValueError("unsupported committed effect resolution")
+        reason = reason.strip()
+        if not reason:
+            raise ValueError("resolution reason is required")
+        with self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            prior = connection.execute(
+                """
+                SELECT detail_json FROM operator_actions
+                WHERE job_id = ? AND action = 'committed_effect_resolution'
+                ORDER BY id DESC LIMIT 1
+                """,
+                (job_id,),
+            ).fetchone()
+            if prior is not None:
+                prior_resolution = json.loads(prior["detail_json"])["resolution"]
+                if prior_resolution == resolution:
+                    return False
+                raise ValueError(f"job {job_id} already has a conflicting resolution")
+            row = connection.execute(
+                """
+                SELECT jobs.task_kind, attempts.id AS attempt_id,
+                       attempts.detail_json AS previous_detail_json
+                FROM jobs
+                JOIN attempts ON attempts.job_id = jobs.id
+                WHERE jobs.id = ? AND jobs.state = 'leased'
+                  AND attempts.status = 'effect_committed'
+                ORDER BY attempts.id DESC LIMIT 1
+                """,
+                (job_id,),
+            ).fetchone()
+            if row is None:
+                raise ValueError(f"job {job_id} has no unresolved committed effect")
+            try:
+                previous_detail = (
+                    json.loads(row["previous_detail_json"])
+                    if row["previous_detail_json"] is not None
+                    else None
+                )
+            except json.JSONDecodeError:
+                previous_detail = {"raw": str(row["previous_detail_json"])}
+            detail = json.dumps(
+                {
+                    "previous_detail": previous_detail,
+                    "reason": reason,
+                    "resolution": resolution,
+                },
+                ensure_ascii=False,
+                sort_keys=True,
+            )
+            connection.execute(
+                """
+                INSERT INTO operator_actions (
+                    action_key, job_id, action, reason, detail_json, created_at
+                ) VALUES (?, ?, 'committed_effect_resolution', ?, ?, ?)
+                """,
+                (
+                    f"committed_effect_resolution:{job_id}:{row['attempt_id']}",
+                    job_id,
+                    reason,
+                    detail,
+                    now.isoformat(),
+                ),
+            )
+            if resolution == "confirmed":
+                receipt = json.dumps(
+                    {
+                        "reason": reason,
+                        "resolution": resolution,
+                        "status": "confirmed_by_operator",
+                    },
+                    ensure_ascii=False,
+                    sort_keys=True,
+                )
+                connection.execute(
+                    """
+                    INSERT OR IGNORE INTO receipts (
+                        job_id, effect_kind, idempotency_key, payload_json, created_at
+                    ) VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (
+                        job_id,
+                        row["task_kind"],
+                        f"job:{job_id}:{row['task_kind']}",
+                        receipt,
+                        now.isoformat(),
+                    ),
+                )
+                connection.execute(
+                    """
+                    UPDATE attempts SET status = 'succeeded', detail_json = ?,
+                        finished_at = ? WHERE id = ?
+                    """,
+                    (detail, now.isoformat(), row["attempt_id"]),
+                )
+                state = "done"
+            else:
+                connection.execute(
+                    """
+                    UPDATE attempts SET status = 'resolved_not_delivered',
+                        detail_json = ?, finished_at = ? WHERE id = ?
+                    """,
+                    (detail, now.isoformat(), row["attempt_id"]),
+                )
+                state = "pending"
+            connection.execute(
+                """
+                UPDATE jobs SET state = ?, available_at = ?, lease_owner = NULL,
+                    lease_until = NULL, lease_token = NULL, cancel_requested = 0
+                WHERE id = ?
+                """,
+                (state, now.isoformat(), job_id),
+            )
+        return True
 
     def list_jobs(self) -> list[Job]:
         with self._connect() as connection:

--- a/bookmark_automation/systemd/bookmark-automation-decisions.service
+++ b/bookmark_automation/systemd/bookmark-automation-decisions.service
@@ -12,6 +12,7 @@ Environment=PYTHONPATH=/workspace/twitter-bookmark-processor
 UnsetEnvironment=ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN OPENAI_API_KEY CODEX_API_KEY CODEX_ACCESS_TOKEN GOOGLE_API_KEY GEMINI_API_KEY AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY CLAUDE_CODE_USE_BEDROCK CLAUDE_CODE_USE_VERTEX CLAUDE_CODE_OAUTH_TOKEN TELEGRAM_BOT_TOKEN TELEGRAM_CHAT_ID OP_SERVICE_ACCOUNT_TOKEN BOOKMARK_AUTOMATION_RUNNER_COMMAND_JSON
 UMask=0077
 ExecCondition=/usr/bin/python3 -m bookmark_automation --db /workspace/twitter-bookmark-processor/data/bookmark-automation.sqlite3 gate
+ExecCondition=/usr/bin/python3 -m bookmark_automation --db /workspace/twitter-bookmark-processor/data/bookmark-automation.sqlite3 operational-gate --path /workspace/twitter-bookmark-processor/data --min-free-bytes 1073741824
 ExecStart=/usr/bin/python3 -m bookmark_automation --db /workspace/twitter-bookmark-processor/data/bookmark-automation.sqlite3 import-decisions --input /workspace/JP/data/twitter_bookmark_actions.jsonl
 NoNewPrivileges=true
 PrivateTmp=true

--- a/bookmark_automation/systemd/bookmark-automation-inference.service
+++ b/bookmark_automation/systemd/bookmark-automation-inference.service
@@ -16,6 +16,7 @@ Environment=CLAUDE_CONFIG_DIR=/root/.claude
 UnsetEnvironment=ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN OPENAI_API_KEY CODEX_API_KEY CODEX_ACCESS_TOKEN GOOGLE_API_KEY GEMINI_API_KEY AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY CLAUDE_CODE_USE_BEDROCK CLAUDE_CODE_USE_VERTEX CLAUDE_CODE_OAUTH_TOKEN TELEGRAM_BOT_TOKEN TELEGRAM_CHAT_ID OP_SERVICE_ACCOUNT_TOKEN BOOKMARK_AUTOMATION_RUNNER_COMMAND_JSON
 UMask=0077
 ExecCondition=/usr/bin/python3 -m bookmark_automation --db /workspace/twitter-bookmark-processor/data/bookmark-automation.sqlite3 gate
+ExecCondition=/usr/bin/python3 -m bookmark_automation --db /workspace/twitter-bookmark-processor/data/bookmark-automation.sqlite3 operational-gate --path /workspace/twitter-bookmark-processor/data --min-free-bytes 1073741824
 ExecStart=/usr/bin/python3 -m bookmark_automation --db /workspace/twitter-bookmark-processor/data/bookmark-automation.sqlite3 worker --max-jobs 1 --worker-id systemd-inference
 NoNewPrivileges=true
 PrivateTmp=true

--- a/bookmark_automation/systemd/bookmark-automation-maintenance.service
+++ b/bookmark_automation/systemd/bookmark-automation-maintenance.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Drain deterministic Twitter bookmark capture and Telegram effects
+Description=Monitor and maintain the Twitter bookmark automation sidecar
 Documentation=file:/workspace/twitter-bookmark-processor/bookmark_automation/README.md
 After=network-online.target
 Wants=network-online.target
@@ -7,7 +7,7 @@ ConditionPathExists=/workspace/twitter-bookmark-processor/data/bookmark-automati
 
 [Service]
 Type=oneshot
-TimeoutStartSec=15min
+TimeoutStartSec=2min
 User=root
 WorkingDirectory=/workspace/twitter-bookmark-processor
 Environment=PYTHONPATH=/workspace/twitter-bookmark-processor
@@ -15,9 +15,9 @@ EnvironmentFile=/etc/bookmark-automation/telegram.env
 UnsetEnvironment=ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN OPENAI_API_KEY CODEX_API_KEY CODEX_ACCESS_TOKEN GOOGLE_API_KEY GEMINI_API_KEY AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY CLAUDE_CODE_USE_BEDROCK CLAUDE_CODE_USE_VERTEX CLAUDE_CODE_OAUTH_TOKEN OP_SERVICE_ACCOUNT_TOKEN BOOKMARK_AUTOMATION_RUNNER_COMMAND_JSON
 UMask=0077
 ExecCondition=/usr/bin/python3 -m bookmark_automation --db /workspace/twitter-bookmark-processor/data/bookmark-automation.sqlite3 gate
-ExecCondition=/usr/bin/python3 -m bookmark_automation --db /workspace/twitter-bookmark-processor/data/bookmark-automation.sqlite3 operational-gate --path /workspace/twitter-bookmark-processor/data --min-free-bytes 1073741824
-ExecStart=/usr/bin/python3 -m bookmark_automation --db /workspace/twitter-bookmark-processor/data/bookmark-automation.sqlite3 effects --max-jobs 1 --worker-id systemd-effects --video-dir /workspace/twitter-bookmark-processor/data/videos --note-dir /workspace/notes/Sources/twitter
+ExecStart=/usr/bin/python3 -m bookmark_automation --db /workspace/twitter-bookmark-processor/data/bookmark-automation.sqlite3 maintenance --video-dir /workspace/twitter-bookmark-processor/data/videos --retention-days 30 --min-free-bytes 1073741824
 NoNewPrivileges=true
 PrivateTmp=true
+ProtectHome=true
 ProtectSystem=strict
-ReadWritePaths=/workspace/twitter-bookmark-processor/data /workspace/notes/Sources/twitter /tmp
+ReadWritePaths=/workspace/twitter-bookmark-processor/data

--- a/bookmark_automation/systemd/bookmark-automation-maintenance.timer
+++ b/bookmark_automation/systemd/bookmark-automation-maintenance.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Monitor bookmark automation every five minutes
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=5min
+AccuracySec=30s
+Persistent=true
+Unit=bookmark-automation-maintenance.service
+
+[Install]
+WantedBy=timers.target

--- a/bookmark_automation/systemd/bookmark-automation-periodic.service
+++ b/bookmark_automation/systemd/bookmark-automation-periodic.service
@@ -13,6 +13,7 @@ Environment=TZ=America/Sao_Paulo
 UnsetEnvironment=ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN OPENAI_API_KEY CODEX_API_KEY CODEX_ACCESS_TOKEN GOOGLE_API_KEY GEMINI_API_KEY AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY CLAUDE_CODE_USE_BEDROCK CLAUDE_CODE_USE_VERTEX CLAUDE_CODE_OAUTH_TOKEN TELEGRAM_BOT_TOKEN TELEGRAM_CHAT_ID OP_SERVICE_ACCOUNT_TOKEN BOOKMARK_AUTOMATION_RUNNER_COMMAND_JSON
 UMask=0077
 ExecCondition=/usr/bin/python3 -m bookmark_automation --db /workspace/twitter-bookmark-processor/data/bookmark-automation.sqlite3 gate --require-note-coverage
+ExecCondition=/usr/bin/python3 -m bookmark_automation --db /workspace/twitter-bookmark-processor/data/bookmark-automation.sqlite3 operational-gate --path /workspace/twitter-bookmark-processor/data --min-free-bytes 1073741824
 ExecStart=/usr/bin/python3 -m bookmark_automation --db /workspace/twitter-bookmark-processor/data/bookmark-automation.sqlite3 schedule --task-kind aggregate --batch-size 25
 ExecStart=/usr/bin/python3 -m bookmark_automation --db /workspace/twitter-bookmark-processor/data/bookmark-automation.sqlite3 schedule --task-kind backlog --batch-size 5
 NoNewPrivileges=true

--- a/bookmark_automation/systemd/bookmark-automation-poll.service
+++ b/bookmark_automation/systemd/bookmark-automation-poll.service
@@ -15,6 +15,7 @@ EnvironmentFile=/etc/bookmark-automation/twitter.env
 UnsetEnvironment=ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN OPENAI_API_KEY CODEX_API_KEY CODEX_ACCESS_TOKEN GOOGLE_API_KEY GEMINI_API_KEY AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY CLAUDE_CODE_USE_BEDROCK CLAUDE_CODE_USE_VERTEX CLAUDE_CODE_OAUTH_TOKEN TELEGRAM_BOT_TOKEN TELEGRAM_CHAT_ID OP_SERVICE_ACCOUNT_TOKEN BOOKMARK_AUTOMATION_RUNNER_COMMAND_JSON
 UMask=0077
 ExecCondition=/usr/bin/python3 -m bookmark_automation --db /workspace/twitter-bookmark-processor/data/bookmark-automation.sqlite3 gate
+ExecCondition=/usr/bin/python3 -m bookmark_automation --db /workspace/twitter-bookmark-processor/data/bookmark-automation.sqlite3 operational-gate --path /workspace/twitter-bookmark-processor/data --min-free-bytes 1073741824
 ExecStart=/bin/bash -o pipefail -c '/usr/bin/bird bookmarks -n 20 --json | /usr/bin/python3 -m bookmark_automation --db /workspace/twitter-bookmark-processor/data/bookmark-automation.sqlite3 ingest --input - --kind bookmarks'
 NoNewPrivileges=true
 PrivateTmp=true

--- a/bookmark_automation/systemd/bookmark-automation-reconcile.service
+++ b/bookmark_automation/systemd/bookmark-automation-reconcile.service
@@ -15,6 +15,7 @@ EnvironmentFile=/etc/bookmark-automation/twitter.env
 UnsetEnvironment=ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN OPENAI_API_KEY CODEX_API_KEY CODEX_ACCESS_TOKEN GOOGLE_API_KEY GEMINI_API_KEY AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY CLAUDE_CODE_USE_BEDROCK CLAUDE_CODE_USE_VERTEX CLAUDE_CODE_OAUTH_TOKEN TELEGRAM_BOT_TOKEN TELEGRAM_CHAT_ID OP_SERVICE_ACCOUNT_TOKEN BOOKMARK_AUTOMATION_RUNNER_COMMAND_JSON
 UMask=0077
 ExecCondition=/usr/bin/python3 -m bookmark_automation --db /workspace/twitter-bookmark-processor/data/bookmark-automation.sqlite3 gate
+ExecCondition=/usr/bin/python3 -m bookmark_automation --db /workspace/twitter-bookmark-processor/data/bookmark-automation.sqlite3 operational-gate --path /workspace/twitter-bookmark-processor/data --min-free-bytes 1073741824
 ExecStart=/bin/bash -o pipefail -c '/usr/bin/bird bookmarks --all --json | /usr/bin/python3 -m bookmark_automation --db /workspace/twitter-bookmark-processor/data/bookmark-automation.sqlite3 ingest --input - --kind bookmarks'
 NoNewPrivileges=true
 PrivateTmp=true

--- a/tests/bookmark_automation/test_cli.py
+++ b/tests/bookmark_automation/test_cli.py
@@ -4,6 +4,7 @@ import io
 import json
 import os
 import sqlite3
+from collections import namedtuple
 from datetime import UTC, datetime
 from pathlib import Path
 from zoneinfo import ZoneInfo
@@ -274,6 +275,61 @@ def test_gate_fails_closed_for_an_uninitialized_database_file(tmp_path: Path) ->
     assert tables == []
 
 
+def test_operational_gate_blocks_workers_below_disk_floor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database = tmp_path / "automation.sqlite3"
+    _bootstrap(database)
+    DiskUsage = namedtuple("DiskUsage", "total used free")
+    free_bytes = [500]
+    monkeypatch.setattr(
+        "bookmark_automation.cli.shutil.disk_usage",
+        lambda _path: DiskUsage(total=10_000, used=9_500, free=free_bytes[0]),
+    )
+    low = io.StringIO()
+
+    assert (
+        main(
+            [
+                "--db",
+                str(database),
+                "operational-gate",
+                "--path",
+                str(tmp_path),
+                "--min-free-bytes",
+                "1000",
+            ],
+            stdout=low,
+        )
+        == 1
+    )
+    assert json.loads(low.getvalue()) == {
+        "free_bytes": 500,
+        "min_free_bytes": 1000,
+        "valid": False,
+    }
+
+    free_bytes[0] = 2_000
+    healthy = io.StringIO()
+    assert (
+        main(
+            [
+                "--db",
+                str(database),
+                "operational-gate",
+                "--path",
+                str(tmp_path),
+                "--min-free-bytes",
+                "1000",
+            ],
+            stdout=healthy,
+        )
+        == 0
+    )
+    assert json.loads(healthy.getvalue())["valid"] is True
+
+
 def test_periodic_schedule_requires_the_exact_note_coverage_gate(tmp_path: Path) -> None:
     database = tmp_path / "automation.sqlite3"
     _bootstrap(database)
@@ -308,7 +364,7 @@ def test_periodic_schedule_requires_the_exact_note_coverage_gate(tmp_path: Path)
     )
 
 
-def test_dead_letter_listing_is_read_only_and_requeue_is_explicitly_unsupported(
+def test_dead_letter_listing_is_read_only_and_advertises_explicit_requeue(
     tmp_path: Path,
 ) -> None:
     database = tmp_path / "automation.sqlite3"
@@ -321,9 +377,263 @@ def test_dead_letter_listing_is_read_only_and_requeue_is_explicitly_unsupported(
     assert json.loads(stdout.getvalue()) == {
         "database_exists": True,
         "jobs": [],
-        "requeue_supported": False,
+        "requeue_supported": True,
     }
     assert database.stat().st_size == before
+
+
+def test_dead_letter_requeue_is_explicit_audited_and_idempotent(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "automation.sqlite3"
+    _bootstrap(database)
+    main(
+        ["--db", str(database), "ingest", "--input", "-", "--kind", "bookmarks"],
+        stdin=io.StringIO(
+            json.dumps([{"id": "failed-bookmark", "text": "Retry after repair"}])
+        ),
+        stdout=io.StringIO(),
+    )
+    store = AutomationStore(database)
+    quick = next(job for job in store.list_jobs() if job.task_kind == "quick")
+    with store._connect() as connection:
+        connection.execute("UPDATE jobs SET state = 'dead_letter' WHERE id = ?", (quick.id,))
+
+    first_stdout = io.StringIO()
+    second_stdout = io.StringIO()
+    command = [
+        "--db",
+        str(database),
+        "dead-letter-requeue",
+        "--job-id",
+        str(quick.id),
+        "--reason",
+        "provider configuration repaired",
+    ]
+
+    assert main(command, stdout=first_stdout) == 0
+    assert main(command, stdout=second_stdout) == 0
+
+    assert json.loads(first_stdout.getvalue()) == {
+        "changed": True,
+        "job_id": quick.id,
+        "state": "pending",
+    }
+    assert json.loads(second_stdout.getvalue()) == {
+        "changed": False,
+        "job_id": quick.id,
+        "state": "pending",
+    }
+    requeued = next(job for job in AutomationStore(database).list_jobs() if job.id == quick.id)
+    assert requeued.state == "pending"
+    with store._connect() as connection:
+        actions = connection.execute(
+            "SELECT action, reason FROM operator_actions WHERE job_id = ?",
+            (quick.id,),
+        ).fetchall()
+    assert [(row["action"], row["reason"]) for row in actions] == [
+        ("dead_letter_requeue", "provider configuration repaired")
+    ]
+
+
+def test_dead_letter_requeue_preserves_frozen_aggregate_input_and_coverage(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "automation.sqlite3"
+    from bookmark_automation.service import BookmarkAutomation
+
+    store = AutomationStore(database)
+    BookmarkAutomation(store).ingest(
+        {"kind": "bookmarks", "id": "aggregate-member", "text": "Frozen input"}
+    )
+    _complete_gates(database, note_coverage=True)
+    scheduled = BookmarkAutomation(store).schedule_periodic(
+        task_kind="aggregate",
+        input_revision="2026-08-08",
+        batch_size=25,
+    )
+    aggregate_id = scheduled.job_ids[0]
+    with store._connect() as connection:
+        frozen_before = connection.execute(
+            "SELECT input_json FROM jobs WHERE id = ?",
+            (aggregate_id,),
+        ).fetchone()["input_json"]
+        coverage_before = connection.execute(
+            """
+            SELECT bookmark_id, input_revision, period_revision, job_id
+            FROM aggregate_coverage WHERE job_id = ?
+            """,
+            (aggregate_id,),
+        ).fetchall()
+        connection.execute(
+            "UPDATE jobs SET state = 'dead_letter' WHERE id = ?",
+            (aggregate_id,),
+        )
+
+    assert store.requeue_dead_letter(
+        job_id=aggregate_id,
+        reason="transient provider failure repaired",
+        now=datetime.now(UTC),
+    )
+
+    with store._connect() as connection:
+        frozen_after = connection.execute(
+            "SELECT input_json FROM jobs WHERE id = ?",
+            (aggregate_id,),
+        ).fetchone()["input_json"]
+        coverage_after = connection.execute(
+            """
+            SELECT bookmark_id, input_revision, period_revision, job_id
+            FROM aggregate_coverage WHERE job_id = ?
+            """,
+            (aggregate_id,),
+        ).fetchall()
+    assert frozen_after == frozen_before
+    assert [tuple(row) for row in coverage_after] == [tuple(row) for row in coverage_before]
+
+
+def test_committed_effect_can_be_confirmed_once_without_reexecution(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "automation.sqlite3"
+    _bootstrap(database)
+    main(
+        ["--db", str(database), "ingest", "--input", "-", "--kind", "bookmarks"],
+        stdin=io.StringIO(json.dumps([{"id": "ambiguous-send", "text": "Maybe sent"}])),
+        stdout=io.StringIO(),
+    )
+    store = AutomationStore(database)
+    notify = next(job for job in store.list_jobs() if job.task_kind == "notify")
+    now = datetime.now(UTC)
+    with store._connect() as connection:
+        connection.execute(
+            """
+            UPDATE jobs SET state = 'leased', lease_owner = 'crashed-worker',
+                lease_until = ?, lease_token = 'expired-token' WHERE id = ?
+            """,
+            (now.isoformat(), notify.id),
+        )
+        connection.execute(
+            """
+            INSERT INTO attempts (
+                job_id, attempt_no, status, detail_json, started_at, finished_at
+            ) VALUES (?, 1, 'effect_committed', ?, ?, ?)
+            """,
+            (
+                notify.id,
+                json.dumps({"operator_action_required": True}),
+                now.isoformat(),
+                now.isoformat(),
+            ),
+        )
+
+    listed = io.StringIO()
+    assert main(["--db", str(database), "committed-effect-list"], stdout=listed) == 0
+    listed_payload = json.loads(listed.getvalue())
+    assert listed_payload["resolution_required"] is True
+    assert listed_payload["jobs"][0]["job_id"] == notify.id
+    assert listed_payload["jobs"][0]["task_kind"] == "notify"
+
+    command = [
+        "--db",
+        str(database),
+        "committed-effect-resolve",
+        "--job-id",
+        str(notify.id),
+        "--resolution",
+        "confirmed",
+        "--reason",
+        "Telegram showed the message",
+    ]
+    first = io.StringIO()
+    second = io.StringIO()
+    assert main(command, stdout=first) == 0
+    assert main(command, stdout=second) == 0
+    assert json.loads(first.getvalue()) == {
+        "changed": True,
+        "job_id": notify.id,
+        "state": "done",
+    }
+    assert json.loads(second.getvalue()) == {
+        "changed": False,
+        "job_id": notify.id,
+        "state": "done",
+    }
+    resolved = next(job for job in AutomationStore(database).list_jobs() if job.id == notify.id)
+    assert resolved.state == "done"
+    receipt = AutomationStore(database).receipt_payload(notify.id, "notify")
+    assert receipt is not None
+    assert receipt["status"] == "confirmed_by_operator"
+    with store._connect() as connection:
+        action = connection.execute(
+            """
+            SELECT detail_json FROM operator_actions
+            WHERE job_id = ? AND action = 'committed_effect_resolution'
+            """,
+            (notify.id,),
+        ).fetchone()
+    audit_detail = json.loads(action["detail_json"])
+    assert audit_detail["previous_detail"] == {"operator_action_required": True}
+
+
+def test_committed_effect_requeues_only_after_not_delivered_is_asserted(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "automation.sqlite3"
+    _bootstrap(database)
+    main(
+        ["--db", str(database), "ingest", "--input", "-", "--kind", "bookmarks"],
+        stdin=io.StringIO(json.dumps([{"id": "known-missed", "text": "Not sent"}])),
+        stdout=io.StringIO(),
+    )
+    store = AutomationStore(database)
+    notify = next(job for job in store.list_jobs() if job.task_kind == "notify")
+    now = datetime.now(UTC)
+    with store._connect() as connection:
+        connection.execute(
+            """
+            UPDATE jobs SET state = 'leased', lease_owner = 'crashed-worker',
+                lease_until = ?, lease_token = 'expired-token' WHERE id = ?
+            """,
+            (now.isoformat(), notify.id),
+        )
+        connection.execute(
+            """
+            INSERT INTO attempts (job_id, attempt_no, status, started_at)
+            VALUES (?, 1, 'effect_committed', ?)
+            """,
+            (notify.id, now.isoformat()),
+        )
+
+    stdout = io.StringIO()
+    assert (
+        main(
+            [
+                "--db",
+                str(database),
+                "committed-effect-resolve",
+                "--job-id",
+                str(notify.id),
+                "--resolution",
+                "not-delivered",
+                "--reason",
+                "Bot API request never left the host",
+            ],
+            stdout=stdout,
+        )
+        == 0
+    )
+
+    assert json.loads(stdout.getvalue())["state"] == "pending"
+    resolved = next(job for job in AutomationStore(database).list_jobs() if job.id == notify.id)
+    assert resolved.state == "pending"
+    assert AutomationStore(database).receipt_payload(notify.id, "notify") is None
+    with store._connect() as connection:
+        attempt = connection.execute(
+            "SELECT status FROM attempts WHERE job_id = ?",
+            (notify.id,),
+        ).fetchone()
+    assert attempt["status"] == "resolved_not_delivered"
 
 
 def test_ingest_cli_accepts_json_batch_from_stdin_and_ignores_likes(tmp_path: Path) -> None:

--- a/tests/bookmark_automation/test_maintenance.py
+++ b/tests/bookmark_automation/test_maintenance.py
@@ -1,0 +1,280 @@
+"""Operational maintenance contracts for the production bookmark loop."""
+
+import io
+import json
+import os
+from collections import namedtuple
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from bookmark_automation.cli import main
+from bookmark_automation.maintenance import MaintenanceWorker
+from bookmark_automation.service import BookmarkAutomation
+from bookmark_automation.store import AutomationStore
+
+
+class RecordingTelegram:
+    def __init__(self) -> None:
+        self.messages: list[Any] = []
+
+    def send_message(self, message: Any, **_: Any) -> Any:
+        self.messages.append(message)
+        return SimpleNamespace(message_id=len(self.messages))
+
+
+def test_maintenance_alerts_each_dead_letter_once(tmp_path: Path) -> None:
+    store = AutomationStore(tmp_path / "automation.sqlite3")
+    now = datetime(2026, 8, 8, 19, 0, tzinfo=UTC)
+    queued = store.enqueue_job(
+        bookmark_id="failed-bookmark",
+        task_kind="quick",
+        input_revision="revision-1",
+        profile="quick",
+        priority=100,
+        now=now,
+    )
+    with store._connect() as connection:
+        connection.execute(
+            "UPDATE jobs SET state = 'dead_letter' WHERE id = ?",
+            (queued.job_id,),
+        )
+        connection.execute(
+            """
+            INSERT INTO attempts (
+                job_id, attempt_no, status, detail_json, started_at, finished_at
+            ) VALUES (?, 1, 'failed', '{}', ?, ?)
+            """,
+            (queued.job_id, now.isoformat(), now.isoformat()),
+        )
+    telegram = RecordingTelegram()
+    worker = MaintenanceWorker(
+        store=store,
+        telegram=telegram,
+        video_dir=tmp_path / "videos",
+    )
+
+    first = worker.run(now=now)
+    second = worker.run(now=now)
+
+    assert first["dead_letter_alerts"] == 1
+    assert second["dead_letter_alerts"] == 0
+    assert len(telegram.messages) == 1
+    assert f"job {queued.job_id}" in telegram.messages[0].text
+    assert "quick" in telegram.messages[0].text
+
+
+def test_failed_dead_letter_alert_is_retried_on_the_next_cycle(tmp_path: Path) -> None:
+    store = AutomationStore(tmp_path / "automation.sqlite3")
+    now = datetime(2026, 8, 8, 19, 2, tzinfo=UTC)
+    queued = store.enqueue_job(
+        bookmark_id="retry-alert",
+        task_kind="quick",
+        input_revision="revision-alert",
+        profile="quick",
+        priority=100,
+        now=now,
+    )
+    with store._connect() as connection:
+        connection.execute(
+            "UPDATE jobs SET state = 'dead_letter' WHERE id = ?",
+            (queued.job_id,),
+        )
+
+    class FailingTelegram:
+        def send_message(self, _message: Any, **_: Any) -> Any:
+            raise RuntimeError("telegram unavailable")
+
+    failing = MaintenanceWorker(
+        store=store,
+        telegram=FailingTelegram(),
+        video_dir=tmp_path / "videos",
+    )
+    with pytest.raises(RuntimeError, match="telegram unavailable"):
+        failing.run(now=now)
+
+    telegram = RecordingTelegram()
+    recovered = MaintenanceWorker(
+        store=store,
+        telegram=telegram,
+        video_dir=tmp_path / "videos",
+    ).run(now=now)
+
+    assert recovered["dead_letter_alerts"] == 1
+    assert len(telegram.messages) == 1
+
+
+def test_maintenance_alerts_unresolved_committed_effect_once(tmp_path: Path) -> None:
+    store = AutomationStore(tmp_path / "automation.sqlite3")
+    now = datetime(2026, 8, 8, 19, 5, tzinfo=UTC)
+    queued = store.enqueue_job(
+        bookmark_id="ambiguous-bookmark",
+        task_kind="notify",
+        input_revision="revision-2",
+        profile="none",
+        priority=100,
+        now=now,
+    )
+    with store._connect() as connection:
+        connection.execute(
+            """
+            UPDATE jobs SET state = 'leased', lease_owner = 'crashed-worker',
+                lease_until = ?, lease_token = 'expired-token' WHERE id = ?
+            """,
+            (now.isoformat(), queued.job_id),
+        )
+        connection.execute(
+            """
+            INSERT INTO attempts (job_id, attempt_no, status, started_at)
+            VALUES (?, 1, 'effect_committed', ?)
+            """,
+            (queued.job_id, now.isoformat()),
+        )
+    telegram = RecordingTelegram()
+    worker = MaintenanceWorker(
+        store=store,
+        telegram=telegram,
+        video_dir=tmp_path / "videos",
+    )
+
+    first = worker.run(now=now)
+    second = worker.run(now=now)
+
+    assert first["committed_effect_alerts"] == 1
+    assert second["committed_effect_alerts"] == 0
+    assert len(telegram.messages) == 1
+    assert f"job {queued.job_id}" in telegram.messages[0].text
+    assert "não será repetido automaticamente" in telegram.messages[0].text
+
+
+def test_maintenance_prunes_only_expired_completed_videos(tmp_path: Path) -> None:
+    store = AutomationStore(tmp_path / "automation.sqlite3")
+    now = datetime(2026, 8, 8, 19, 10, tzinfo=UTC)
+    video_dir = tmp_path / "videos"
+    video_dir.mkdir()
+    old = video_dir / "old-video.mp4"
+    recent = video_dir / "recent-video.mp4"
+    unresolved = video_dir / "unresolved-video.mp4"
+    old.write_bytes(b"old")
+    recent.write_bytes(b"recent")
+    unresolved.write_bytes(b"pending")
+    old_timestamp = (now - timedelta(days=31)).timestamp()
+    recent_timestamp = (now - timedelta(days=2)).timestamp()
+    os.utime(old, (old_timestamp, old_timestamp))
+    os.utime(recent, (recent_timestamp, recent_timestamp))
+    os.utime(unresolved, (old_timestamp, old_timestamp))
+    queued: dict[str, int] = {}
+    for bookmark_id in ("old-video", "recent-video", "unresolved-video"):
+        queued[bookmark_id] = store.enqueue_job(
+            bookmark_id=bookmark_id,
+            task_kind="deliver_video",
+            input_revision="revision-video",
+            profile="none",
+            priority=100,
+            now=now,
+        ).job_id
+    with store._connect() as connection:
+        connection.execute(
+            "UPDATE jobs SET state = 'done' WHERE id IN (?, ?)",
+            (queued["old-video"], queued["recent-video"]),
+        )
+    worker = MaintenanceWorker(
+        store=store,
+        telegram=RecordingTelegram(),
+        video_dir=video_dir,
+        retention_days=30,
+    )
+
+    result = worker.run(now=now)
+
+    assert result["videos_removed"] == 1
+    assert result["bytes_removed"] == 3
+    assert not old.exists()
+    assert recent.exists()
+    assert unresolved.exists()
+
+
+def test_maintenance_alerts_once_per_low_disk_incident(tmp_path: Path) -> None:
+    store = AutomationStore(tmp_path / "automation.sqlite3")
+    telegram = RecordingTelegram()
+    DiskUsage = namedtuple("DiskUsage", "total used free")
+    free_bytes = [100]
+
+    def disk_usage(_path: Path) -> Any:
+        return DiskUsage(total=10_000, used=10_000 - free_bytes[0], free=free_bytes[0])
+
+    worker = MaintenanceWorker(
+        store=store,
+        telegram=telegram,
+        video_dir=tmp_path / "videos",
+        min_free_bytes=1_000,
+        disk_usage=disk_usage,
+    )
+    now = datetime(2026, 8, 8, 19, 20, tzinfo=UTC)
+
+    first = worker.run(now=now)
+    repeated = worker.run(now=now)
+    free_bytes[0] = 2_000
+    recovered = worker.run(now=now)
+    free_bytes[0] = 100
+    relapsed = worker.run(now=now)
+
+    assert first["healthy"] is False
+    assert first["disk_alerts"] == 1
+    assert repeated["disk_alerts"] == 0
+    assert recovered["healthy"] is True
+    assert relapsed["disk_alerts"] == 1
+    assert len(telegram.messages) == 2
+    assert all("disco baixo" in message.text for message in telegram.messages)
+
+
+def test_maintenance_cli_runs_the_bounded_operational_cycle(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    database = tmp_path / "automation.sqlite3"
+    store = AutomationStore(database)
+    BookmarkAutomation(store).ingest(
+        {"kind": "bookmarks", "id": "bootstrap-seed", "text": "Seed"},
+        bootstrap=True,
+    )
+    store.mark_bootstrap_completed(
+        now=datetime.now(UTC),
+        accepted=1,
+        expected_minimum=1,
+    )
+    telegram = RecordingTelegram()
+    monkeypatch.setattr(
+        "bookmark_automation.cli.TelegramClient",
+        lambda **_: telegram,
+    )
+    stdout = io.StringIO()
+
+    assert (
+        main(
+            [
+                "--db",
+                str(database),
+                "maintenance",
+                "--video-dir",
+                str(tmp_path / "videos"),
+                "--retention-days",
+                "30",
+                "--min-free-bytes",
+                "1",
+            ],
+            stdout=stdout,
+        )
+        == 0
+    )
+    payload = json.loads(stdout.getvalue())
+    assert payload["healthy"] is True
+    assert payload["dead_letter_alerts"] == 0
+    assert payload["committed_effect_alerts"] == 0
+    assert payload["database_bytes"] > 0
+    assert payload["wal_bytes"] >= 0
+    assert payload["wal_checkpoint_busy"] in {0, 1}
+    assert payload["wal_checkpointed_frames"] >= 0

--- a/tests/bookmark_automation/test_systemd.py
+++ b/tests/bookmark_automation/test_systemd.py
@@ -64,3 +64,29 @@ def test_reconciliation_is_full_but_live_and_decisions_never_poll_telegram() -> 
     assert "TimeoutStartSec=2min" in poll
     assert "twitter_bookmark_actions.jsonl" in decisions
     assert "getUpdates" not in decisions
+
+
+def test_runtime_workers_fail_closed_below_the_storage_floor() -> None:
+    services = sorted(SYSTEMD.glob("*.service"))
+    workers = [path for path in services if path.name != "bookmark-automation-maintenance.service"]
+    operational_gate = (
+        "ExecCondition=/usr/bin/python3 -m bookmark_automation --db "
+        "/workspace/twitter-bookmark-processor/data/bookmark-automation.sqlite3 "
+        "operational-gate --path /workspace/twitter-bookmark-processor/data "
+        "--min-free-bytes 1073741824"
+    )
+
+    assert workers
+    assert all(operational_gate in path.read_text(encoding="utf-8") for path in workers)
+
+
+def test_maintenance_timer_alerts_and_prunes_without_being_blocked_by_low_disk() -> None:
+    service = _unit("bookmark-automation-maintenance.service")
+    timer = _unit("bookmark-automation-maintenance.timer")
+
+    assert "EnvironmentFile=/etc/bookmark-automation/telegram.env" in service
+    assert "maintenance --video-dir /workspace/twitter-bookmark-processor/data/videos" in service
+    assert "--retention-days 30 --min-free-bytes 1073741824" in service
+    assert "operational-gate" not in service
+    assert "ReadWritePaths=/workspace/twitter-bookmark-processor/data" in service
+    assert "OnUnitActiveSec=5min" in timer


### PR DESCRIPTION
## Resultado
- adiciona alerta Telegram idempotente para novas gerações de dead letter
- adiciona requeue explícito, auditado e idempotente sem alterar input/coverage
- adiciona listagem e resolução auditada de efeitos externos ambíguos, sem replay cego
- adiciona retenção segura de vídeos concluídos, checkpoint/métricas de SQLite WAL e alerta de disco baixo
- bloqueia workers abaixo de 1 GiB livre e mantém maintenance disponível para alertar/prunar
- adiciona o sétimo par systemd (`bookmark-automation-maintenance`)

## Validação
- `PYTHONPATH=. pytest -q tests/bookmark_automation` — 181 passed
- `ruff check bookmark_automation tests/bookmark_automation` — clean
- `python3 -m compileall -q bookmark_automation tests/bookmark_automation` — clean
- `systemd-analyze verify bookmark_automation/systemd/*.service bookmark_automation/systemd/*.timer` — clean
- `git diff --check` — clean

A suíte legada global foi iniciada e expôs falhas preexistentes em `tests/test_config.py` e `tests/test_insight_capture.py`; nenhum arquivo sob `src/` foi alterado e o teste de integração legado ficou bloqueado até ser interrompido. A suíte integral do sidecar afetado passa.

Review automatizada não solicitada: o escopo foi testado por TDD e revisado contra os gates de produção.