### PR TITLE
fix: treat X-only article links as not applicable

### DIFF
--- a/bookmark_automation/effect_worker.py
+++ b/bookmark_automation/effect_worker.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, Mapping, Protocol
 
 from .content import (
     ArticleContent,
+    ArticleContentError,
     RecallResult,
     fetch_article,
     recall_second_brain,
@@ -252,7 +253,15 @@ class EffectWorker:
                 "telegram_sha256": delivered.sha256,
             }
         if task_kind == "fetch_article":
-            article = self.fetch_article_content(payload)
+            try:
+                article = self.fetch_article_content(payload)
+            except ArticleContentError as exc:
+                if exc.code not in {
+                    "article_target_excluded",
+                    "article_url_unavailable",
+                }:
+                    raise
+                return {"status": "not_applicable", "reason": exc.code}
             return {"status": "available", **asdict(article)}
         if task_kind == "recall_context":
             recalled = self.recall_context(self.store.recall_query(job))

--- a/bookmark_automation/worker.py
+++ b/bookmark_automation/worker.py
@@ -308,7 +308,7 @@ class InferenceWorker:
         bookmark = job_input.get("bookmark") or {}
 
         article_status = str(article.get("status") or evidence_status.get("fetch_article") or "")
-        if not article_status:
+        if not article_status or article_status == "not_applicable":
             content_status = "not_applicable"
         elif article_status == "available":
             content_status = "partial" if article.get("truncated") else "available"
@@ -338,7 +338,7 @@ class InferenceWorker:
         source["source_url"] = (
             article.get("final_url") or article.get("original_url") or tweet_url
         )
-        if article_status:
+        if article_status and article_status != "not_applicable":
             # External article metadata must not silently inherit the tweet's
             # author/date. Embedded X Articles already carry those values in
             # their deterministic fetch receipt.

--- a/tests/bookmark_automation/test_effect_worker.py
+++ b/tests/bookmark_automation/test_effect_worker.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any
 
 import bookmark_automation.effect_worker as effect_worker_module
-from bookmark_automation.content import ArticleContent, RecallResult
+from bookmark_automation.content import ArticleContent, ArticleContentError, RecallResult
 from bookmark_automation.effect_worker import EffectWorker
 from bookmark_automation.effects import ExternalEffectError, TelegramReceipt, VideoReceipt
 from bookmark_automation.notes import write_source_note
@@ -326,6 +326,48 @@ def test_effect_worker_captures_article_and_local_recall_as_separate_receipts(
     assert recall_receipt is not None
     assert recall_receipt["status"] == "available"
     assert recall_receipt["hits"][0]["path"] == "Concepts/Memory.md"
+
+
+def test_x_redirect_without_external_article_is_a_safe_terminal_receipt(
+    tmp_path: Path,
+) -> None:
+    now = datetime(2026, 8, 8, 13, 22, tzinfo=UTC)
+    store = AutomationStore(tmp_path / "automation.sqlite3")
+    BookmarkAutomation(store, clock=lambda: now).ingest(
+        {
+            "kind": "bookmarks",
+            "id": "1900000000000000199",
+            "text": "A t.co URL that resolves back to X",
+            "urls": [{"expanded_url": "https://t.co/not-an-article"}],
+        }
+    )
+
+    def excluded(_payload: dict[str, Any]) -> ArticleContent:
+        raise ArticleContentError(
+            "redirected back to X",
+            code="article_target_excluded",
+            retryable=False,
+        )
+
+    worker = EffectWorker(
+        store=store,
+        telegram=RecordingTelegram(),
+        worker_id="effect-test",
+        video_dir=tmp_path / "videos",
+        note_dir=tmp_path / "notes",
+        fetch_article_content=excluded,
+    )
+
+    outcome = worker.run_once(now=now, task_kinds={"fetch_article"})
+
+    assert outcome is not None and outcome.status == "done"
+    job = next(job for job in store.list_jobs() if job.task_kind == "fetch_article")
+    assert job.state == "done"
+    assert store.receipt_payload(job.id, "fetch_article") == {
+        "reason": "article_target_excluded",
+        "status": "not_applicable",
+    }
+    assert store.status_snapshot()["dead_letter"] == 0
 
 
 def test_skip_during_reversible_article_fetch_cancels_without_a_receipt(

--- a/tests/bookmark_automation/test_materialization.py
+++ b/tests/bookmark_automation/test_materialization.py
@@ -271,6 +271,55 @@ def test_external_article_without_byline_does_not_inherit_tweet_metadata(
     assert source["published_at"] is None
 
 
+def test_not_applicable_article_uses_tweet_provenance(
+    tmp_path: Path,
+) -> None:
+    now = datetime(2026, 8, 8, 14, 20, tzinfo=UTC)
+    store = AutomationStore(tmp_path / "automation.sqlite3")
+    bookmark_id = "1900000000000000204"
+    BookmarkAutomation(store, clock=lambda: now).ingest(
+        {
+            "kind": "bookmarks",
+            "id": bookmark_id,
+            "text": "A t.co URL that resolves back to X",
+            "author": {"username": "real_handle", "name": "Real Author"},
+            "createdAt": "2026-08-07T12:34:56.000Z",
+            "urls": [{"expanded_url": "https://t.co/not-an-article"}],
+        }
+    )
+    jobs = {job.task_kind: job for job in store.list_jobs()}
+    for task_kind, payload in (
+        ("quick", {"status": "available"}),
+        ("recall_context", {"status": "available", "hits": []}),
+        (
+            "fetch_article",
+            {"status": "not_applicable", "reason": "article_target_excluded"},
+        ),
+    ):
+        store.complete_effect(
+            job_id=jobs[task_kind].id,
+            effect_kind=task_kind,
+            payload=payload,
+            now=now,
+        )
+
+    outcome = InferenceWorker(
+        store=store,
+        runner=DeepRunner(),
+        worker_id="metadata-test",
+    ).run_once(now=now + timedelta(minutes=16))
+
+    assert outcome is not None and outcome.status == "done"
+    note_job = next(
+        job for job in store.list_jobs() if job.task_kind == "write_source_note"
+    )
+    source = store.job_payload(note_job)["analysis"]["source_note"]
+    assert source["source_url"] == f"https://x.com/real_handle/status/{bookmark_id}"
+    assert source["author"] == "Real Author"
+    assert source["published_at"] == "2026-08-07T12:34:56.000Z"
+    assert source["provenance"]["content_status"] == "not_applicable"
+
+
 def test_deep_never_preserves_hallucinated_source_metadata_when_capture_is_missing(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Resultado
- trata somente `article_target_excluded` e `article_url_unavailable` como evidência terminal `not_applicable`
- mantém erros reais de transporte, tamanho, redirects inválidos e conteúdo inseguro no fluxo normal de retry/DLQ
- impede que um `t.co` que volta ao próprio X gere dead letter falso

## Evidência
- RED real no lote periódico: job 9 entrou em DLQ com `article_target_excluded`
- teste TDD reproduziu o estado `dead_letter`
- GREEN: receipt `not_applicable`, job `done`, zero DLQ
- `PYTHONPATH=. pytest -q tests/bookmark_automation` — 183 passed
- Ruff e diff check limpos

Review automatizada não solicitada: correção causal e estritamente limitada a dois códigos seguros.