### PR TITLE
Fix production recall timeout budget

### DIFF
--- a/bookmark_automation/content.py
+++ b/bookmark_automation/content.py
@@ -555,7 +555,7 @@ def recall_second_brain(
     query: str,
     *,
     limit: int = 12,
-    timeout: float = 15.0,
+    timeout: float = 30.0,
     runner: Callable[..., Any] = subprocess.run,
     script_path: str | Path = "/workspace/_scripts/memory/recall.py",
 ) -> RecallResult:

--- a/tests/bookmark_automation/test_content.py
+++ b/tests/bookmark_automation/test_content.py
@@ -616,3 +616,15 @@ def test_second_brain_recall_timeout_is_typed_and_retryable() -> None:
 
     assert captured.value.code == "recall_timeout"
     assert captured.value.retryable is True
+
+
+def test_second_brain_recall_default_timeout_covers_long_production_queries() -> None:
+    observed: dict[str, Any] = {}
+
+    def runner(_command: list[str], **kwargs: Any) -> Any:
+        observed.update(kwargs)
+        return SimpleNamespace(stdout="[]")
+
+    recall_second_brain("a bounded but long production query", runner=runner)
+
+    assert observed["timeout"] == 30.0


### PR DESCRIPTION
Raises the bounded local recall timeout from 15s to 30s after measuring a real periodic query at 17.3s. Preserves explicit overrides and typed failure behavior.\n\nValidation: 185 bookmark automation tests passed; git diff --check clean.